### PR TITLE
Remove minimum-stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
         "surfnet"
     ],
     "license": "Apache-2.0",
-    "minimum-stability": "stable",
     "autoload": {
         "psr-0": {
             "Surfnet\\YubikeyApiClient\\": "src",


### PR DESCRIPTION
This line is unnecessary because it is the default of composer.