### PR TITLE
cache only downloaded packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 
 cache:
   directories:
-    - ~/.composer
+    - ~/.composer/cache/files
 
 before_script:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-add .travis.php.ini; fi


### PR DESCRIPTION
Caching metadata downloaded from packagist makes the cache being
invalidated too often.