### PR TITLE
Run Travis CI on container-based infrastructure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@
 # This file should be added to your project repository
 #
 
+sudo: false
+
 language: php
 
 php:


### PR DESCRIPTION
Attempt to run Travis CI on container-based infrastructure to enable Composer cache, which is only available for private repositories and Travis' new container-based infrastructure.

See:
 * [Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching)
 * [Routing your build to container-based infrastructure](https://docs.travis-ci.com/user/workers/container-based-infrastructure/#Routing-your-build-to-container-based-infrastructure)

In preparation for #14.