### PR TITLE
Update yubikey-api-client and PHP minimum version requirement to 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ sudo: false
 language: php
 
 php:
-  - 5.4
-  - 5.5
+  - 5.6
+  - 7
   - hhvm
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         }
     },
     "require": {
-        "php": "^5.4|^7.0",
-        "surfnet/yubikey-api-client": "^1.0",
+        "php": "^5.6|^7.0",
+        "surfnet/yubikey-api-client": "^2.0",
         "symfony/config": "^2.7|^3.0",
         "symfony/dependency-injection": "^2.7|^3.0",
         "symfony/http-kernel": "^2.7|^3.0"


### PR DESCRIPTION
[137540029](https://www.pivotaltracker.com/story/show/137540029)

The yubikey-api-client has been updated for [security reasons](https://github.com/SURFnet/yubikey-api-client/pull/3).

This is a BC break that warrants a major release.